### PR TITLE
Update irc.py to catch invalid UTF-8, and then try Latin-1

### DIFF
--- a/gpt2_bot/irc.py
+++ b/gpt2_bot/irc.py
@@ -62,7 +62,11 @@ class IRCBot:
         # Main event loop
         while True:
             # HACK
-            lines = self.socket.recv(524288).decode("UTF-8")
+            raw_data = self.socket.recv(524288)
+            try:
+                lines = raw_data.decode("UTF-8")
+            except UnicodeDecodeError:
+                lines = raw_data.decode("latin-1")
             for line in lines.splitlines():
                 self.__debug(">>>"+line)
                 self.__process_line(line)


### PR DESCRIPTION
Catches invalid UTF-8 (for example, if a multi-byte unicode character gets cut off.
For example, if "\xF0\x9F\x92\x9C" is cut off and only shows the first character for example, it will fail to decode as UTF-8, but Latin-1 will always succeed

This should fix issue #3, following a similar pattern to how irctokens handles fallback encodings https://github.com/jesopo/irctokens/blob/master/irctokens/line.py#L105-L108